### PR TITLE
:bug: extract file name updated

### DIFF
--- a/apps/common/utils.py
+++ b/apps/common/utils.py
@@ -90,7 +90,7 @@ def generate_material_signed_url(object_key, expiration=300, original_filename=N
 def generate_unique_filename(filename):
     """UUID + 원본 파일명 + 확장자로 파일명 생성하는 함수"""
     name, ext = os.path.splitext(filename)  # 파일명과 확장자 분리
-    return f"{name}_{uuid.uuid4()}{ext}"  # UUID + 원본 파일명 + 확장자
+    return f"{name}_{uuid.uuid4()}{ext}"  # 원본 파일명 + UUID + 확장자
 
 
 def class_lecture_file_path(instance, filename):

--- a/apps/courses/serializers.py
+++ b/apps/courses/serializers.py
@@ -96,13 +96,17 @@ class LectureChapterSerializer(serializers.ModelSerializer):
     @staticmethod
     def extract_original_filename(file_name):
         """
-        파일명에서 UUID 및 접두어(materials_) 제거하여 원래 파일명만 반환
+        파일명에서 UUID 및 구분자 (_) 제거하여 원래 파일명만 반환
         """
-        pattern = r"^(?:materials_)?[\w-]+_([\w가-힣.-]+)$"
+        # 파일명과 확장자 분리
+        name, ext = os.path.splitext(file_name)
 
-        match = re.match(pattern, file_name)
+        # UUID 패턴: 8-4-4-4-12 (총 36자)
+        pattern = r"^(?:materials_)?(.*)_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+
+        match = re.match(pattern, name)
         if match:
-            return match.group(1)  # UUID 제거 후 원래 파일명 반환
+            return f"{match.group(1)}{ext}"  # UUID 제거된 파일명 + 확장자
         return file_name  # 매칭 안 되면 기존 파일명 반환
 
     def generate_signed_url(self, obj):


### PR DESCRIPTION
파일명을 배포서버에서 제대로 추출하지 못하는 문제를 해결하였읍니다. 

이유: 로컬에서는 경로 + uuid + 파일명 . 확장자 (초기코드) 로 ncp 에 올라간 파일ㄹ로 테스트함 
배포는 정상적으로 경로 + 파일명 + uuid . 확장자 (초기코드) 로 ncp 에 올라감 

그래서 테스트를 옛날 ncp 파일명으로 하니 그에 맞는 코드를 작성해서 생긴 문제 


+ @ staticmethod 는 self 를 추가하면 스태틱 메소드가 필요없지만 
클래스 내부 상태 안 쓰는데 self 받을 필요 없는데 self 를 쓰면 비효율적이라고 함 
따라서 데코레이터를 쓰는게 가장 Pythonic하고 명확 하다고 함수


